### PR TITLE
Errors when compiling with latest glib

### DIFF
--- a/src/auto/color_chooser_request.rs
+++ b/src/auto/color_chooser_request.rs
@@ -97,7 +97,7 @@ impl<O: IsA<ColorChooserRequest>> ColorChooserRequestExt for O {
         unsafe {
             let mut value = Value::from_type(<gdk::RGBA as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"rgba\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get()
+            value.get().unwrap()
         }
     }
 

--- a/src/auto/file_chooser_request.rs
+++ b/src/auto/file_chooser_request.rs
@@ -93,7 +93,7 @@ impl<O: IsA<FileChooserRequest>> FileChooserRequestExt for O {
         unsafe {
             let mut value = Value::from_type(<gtk::FileFilter as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"filter\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get()
+            value.get().unwrap()
         }
     }
 

--- a/src/auto/find_controller.rs
+++ b/src/auto/find_controller.rs
@@ -122,7 +122,7 @@ impl<O: IsA<FindController>> FindControllerExt for O {
         unsafe {
             let mut value = Value::from_type(<GString as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"text\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get()
+            value.get().unwrap()
         }
     }
 

--- a/src/auto/print_operation.rs
+++ b/src/auto/print_operation.rs
@@ -109,7 +109,7 @@ impl<O: IsA<PrintOperation>> PrintOperationExt for O {
         unsafe {
             let mut value = Value::from_type(<WebView as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"web-view\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get()
+            value.get().unwrap()
         }
     }
 

--- a/src/auto/user_media_permission_request.rs
+++ b/src/auto/user_media_permission_request.rs
@@ -42,7 +42,7 @@ impl<O: IsA<UserMediaPermissionRequest>> UserMediaPermissionRequestExt for O {
         unsafe {
             let mut value = Value::from_type(<bool as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"is-for-audio-device\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get().unwrap()
+            value.get().unwrap().unwrap()
         }
     }
 
@@ -50,7 +50,7 @@ impl<O: IsA<UserMediaPermissionRequest>> UserMediaPermissionRequestExt for O {
         unsafe {
             let mut value = Value::from_type(<bool as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"is-for-video-device\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get().unwrap()
+            value.get().unwrap().unwrap()
         }
     }
 

--- a/src/auto/web_context.rs
+++ b/src/auto/web_context.rs
@@ -447,7 +447,7 @@ impl<O: IsA<WebContext>> WebContextExt for O {
         unsafe {
             let mut value = Value::from_type(<GString as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"local-storage-directory\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get()
+            value.get().unwrap()
         }
     }
 

--- a/src/auto/web_view.rs
+++ b/src/auto/web_view.rs
@@ -982,7 +982,7 @@ impl<O: IsA<WebView>> WebViewExt for O {
         unsafe {
             let mut value = Value::from_type(<bool as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"editable\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get().unwrap()
+            value.get().unwrap().unwrap()
         }
     }
 
@@ -991,7 +991,7 @@ impl<O: IsA<WebView>> WebViewExt for O {
         unsafe {
             let mut value = Value::from_type(<bool as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"is-controlled-by-automation\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get().unwrap()
+            value.get().unwrap().unwrap()
         }
     }
 
@@ -1000,7 +1000,7 @@ impl<O: IsA<WebView>> WebViewExt for O {
         unsafe {
             let mut value = Value::from_type(<bool as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"is-ephemeral\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get().unwrap()
+            value.get().unwrap().unwrap()
         }
     }
 
@@ -1017,7 +1017,7 @@ impl<O: IsA<WebView>> WebViewExt for O {
         unsafe {
             let mut value = Value::from_type(<bool as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"is-playing-audio\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get().unwrap()
+            value.get().unwrap().unwrap()
         }
     }
 

--- a/src/auto/web_view.rs
+++ b/src/auto/web_view.rs
@@ -1008,7 +1008,7 @@ impl<O: IsA<WebView>> WebViewExt for O {
         unsafe {
             let mut value = Value::from_type(<bool as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"is-loading\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get().unwrap()
+            value.get().unwrap().unwrap()
         }
     }
 
@@ -1025,7 +1025,7 @@ impl<O: IsA<WebView>> WebViewExt for O {
         unsafe {
             let mut value = Value::from_type(<WebContext as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"web-context\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get()
+            value.get().unwrap()
         }
     }
 

--- a/src/auto/website_data_manager.rs
+++ b/src/auto/website_data_manager.rs
@@ -252,7 +252,7 @@ impl<O: IsA<WebsiteDataManager>> WebsiteDataManagerExt for O {
         unsafe {
             let mut value = Value::from_type(<bool as StaticType>::static_type());
             gobject_sys::g_object_get_property(self.to_glib_none().0 as *mut gobject_sys::GObject, b"is-ephemeral\0".as_ptr() as *const _, value.to_glib_none_mut().0);
-            value.get().unwrap()
+            value.get().unwrap().unwrap()
         }
     }
 }


### PR DESCRIPTION
I have got errors like below while compiling with the latest 'glib'.

```
fn get_property_filter(&self) -> Option<gtk::FileFilter> {
   |                                      ----------------------- expected `std::option::Option<gtk::FileFilter>` because of return type
...
96 |             value.get()
   |             ^^^^^^^^^^^ expected enum `std::option::Option`, found enum `std::result::Result`
   |
   = note: expected enum `std::option::Option<gtk::FileFilter>`
              found enum `std::result::Result<std::option::Option<_>, glib::value::GetError>`

```

This PR will fix errors like these.